### PR TITLE
list_template_guids now can show if on cluster or provider

### DIFF
--- a/automate/rhc-miq-quickstart/Service/DynamicDialogs.class/__methods__/list_template_guids.rb
+++ b/automate/rhc-miq-quickstart/Service/DynamicDialogs.class/__methods__/list_template_guids.rb
@@ -29,6 +29,7 @@ module RhcMiqQuickstart
         class ListTemplateGuilds
 
           include RedHatConsulting_Utilities::StdLib::Core
+          DISPLAY_ON = 'cluster'.freeze # 'cluster' or 'provider'
 
           def initialize(handle = $evm)
             @handle = handle
@@ -43,12 +44,14 @@ module RhcMiqQuickstart
             dialog_hash = {}
             @handle.vmdb(:miq_template).all.each do |template|
               if object_eligible?(template)
-                dialog_hash[template[:guid]] = "#{template.name} on #{template.ext_management_system.name}"
+                on = ' on ' + template.host.ems_cluster.name if DISPLAY_ON == 'cluster'
+                on = ' on ' + template.ext_management_system.name if DISPLAY_ON == 'provider'
+                dialog_hash[template[:guid]] = "#{template.name}#{on}"
               end
             end
 
             if dialog_hash.blank?
-              dialog_hash[''] = "< No templates found tagged with #{rbac_array} >"
+              dialog_hash[''] = "< No templates found tagged with #{@rbac_array} >"
             else
               @handle.object['default_value'] = dialog_hash.first[0]
             end

--- a/automate/rhc-miq-quickstart/Service/Provisioning/StateMachines/Methods.class/__methods__/build_vm_provision_request.yaml
+++ b/automate/rhc-miq-quickstart/Service/Provisioning/StateMachines/Methods.class/__methods__/build_vm_provision_request.yaml
@@ -12,5 +12,6 @@ object:
     embedded_methods:
     - "/StdLib/Core/Core"
     - "/Common/FlavorConfig/flavorconfig"
+    - "/StdLib/Settings/Settings"
     options: {}
   inputs: []

--- a/service_dialogs/generic_build_vmprovision_request_based_on_choosing_a_template_3_tier.yml
+++ b/service_dialogs/generic_build_vmprovision_request_based_on_choosing_a_template_3_tier.yml
@@ -1,7 +1,7 @@
 ---
 - description:
   buttons: submit,cancel
-  label: generic_build_vmprovision_request_based_on_choosing_a_template_3_tier
+  label: RHC_generic_build_vmprovision_request_based_on_choosing_a_template_3_tier
   dialog_tabs:
   - description:
     display: edit


### PR DESCRIPTION
bvpr: now leverage settings.rb for a few things, default vlan/network/dvs, retirement
      reintroduce copying tags to the service from the SC tags, to keep in sync catalog item & live service RBAC tags
      more liberal requesting user ID lookup (also search for the textual userid)